### PR TITLE
Fix: Navbar styling in dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
 <body {% block body_attributes %}{% endblock body_attributes %}> {# Body Attributes: Allows customization of body tag (e.g. for specific page classes) #}
     <header>
         {% block header %} {# Header Block: Contains site header, typically navigation. #}
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav class="navbar navbar-expand-lg">
             <div class="container-fluid">
                 <a class="navbar-brand" href="#">Site Title</a>
                 <button id="preferencesPopoverButton" class="btn btn-outline-secondary ms-auto" type="button" aria-label="Display settings" aria-haspopup="true">


### PR DESCRIPTION
The navbar in templates/base.html was using fixed classes 'navbar-light bg-light', which caused styling issues when dark mode was enabled.

This commit removes these explicit classes from the navbar. Now, the navbar will rely on Bootstrap's built-in CSS variables and the 'data-bs-theme' attribute on the HTML element. This ensures that the navbar's background and text colors automatically adapt to the currently active theme (light or dark), resolving the styling clash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the navigation bar styling by removing the light background and light-themed text, resulting in a modified appearance for the navbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->