### PR TITLE
Fix: Correct Jinja ternary operator in user profile badge

### DIFF
--- a/templates/macros/common_blocks.html
+++ b/templates/macros/common_blocks.html
@@ -20,7 +20,7 @@
     {% else %}
     {# Placeholder avatar: initials or generic icon #}
     <span class="avatar-placeholder rounded-circle me-2 d-flex align-items-center justify-content-center bg-secondary text-white" style="width: {{ current_img_size }}; height: {{ current_img_size }};">
-        {{ user_name[0]|upper if user_name }}
+        {{ user_name[0]|upper if user_name else '' }}
     </span>
     {% endif %}
     {% if profile_url %}


### PR DESCRIPTION
The `render_user_profile_badge` macro in `templates/macros/common_blocks.html` used a ternary conditional `{{ user_name[0]|upper if user_name }}` to display your initial. This was missing the required `else` clause, leading to a `jinja2.exceptions.TemplateSyntaxError`.

This commit fixes the error by adding an `else ''` to the expression, ensuring that an empty string is rendered if `user_name` is not available or empty. The corrected expression is `{{ user_name[0]|upper if user_name else '' }}`.